### PR TITLE
Allow unpublishing a page with blank publish_from

### DIFF
--- a/SchedulePages.module
+++ b/SchedulePages.module
@@ -157,7 +157,8 @@ class SchedulePages extends WireData implements Module, ConfigurableModule {
 			// Publish pages with a publish_until date > current date (and publish_until is set)
 			if ($p->publish_until > 0 && $p->publish_until <= $time) {
 				// We keep it unpublished, since publish until is set and valid
-				} else {
+			} else if ($p->publish_from) {
+				// If publish_from is defined, publish page
 				$p->removeStatus(Page::statusUnpublished);
 				$p->save();
 			}


### PR DESCRIPTION
If page has publish_until set but publish_from is left blank, user should IMHO still be able to unpublish said page even before that date.. and if this isn't desired, it's still possible to prevent simply by filling in a value to publish_from field.

Without this change pages scheduled to be unpublished at some future date can't be unpublished manually, which makes tasks such as unpublishing pages via other modules and (lazy or regular) cron tasks either impossible or more difficult and less generic, since publish_until has to be cleared at the same time.
