### PR TITLE
Added feature: Always use “Publish From Date” field to store publishing timestamp

### DIFF
--- a/README
+++ b/README
@@ -44,3 +44,4 @@ Version history:
 1.0.1	Minor bugfixes
 1.1.0	Added debug feature and fixed a publication bug
 1.1.1	Added full language support and renamed $time variable to $currenttime
+1.2.0	Added feature: Always use “Publish From Date” field to store publishing timestamp

--- a/SchedulePages.module
+++ b/SchedulePages.module
@@ -59,7 +59,7 @@ class SchedulePages extends WireData implements Module, ConfigurableModule {
 			'title' => 'Schedule Pages',
 
 			// version: major, minor, revision, i.e. 100 = 1.0.0
-			'version' => 111,
+			'version' => 120,
 
 			// summary is brief description of what this module is
 			'summary' => 'This module allows scheduling (un)publication of pages.',
@@ -105,6 +105,18 @@ class SchedulePages extends WireData implements Module, ConfigurableModule {
 	public function afterSave($event) {
 		$page = $event->arguments[0];
 
+		// Fill the publish_from field automatically with the current timestamp
+		// in case a page is published manually
+		if ($this->autofillPublishFrom == "1") {
+			// Don’t touch unpublished pages.
+			// Don’t touch pages with the publish_from field already filled.
+			// Don’t touch pages which don’t have a publish_from field.
+			if ($page->is(Page::statusUnpublished) || $page->publish_from || !$page->template->hasField('publish_from')) return;
+			//if page is published and publish_from not populated, add current timestamp
+			$page->publish_from = time();
+			$page->save('publish_from');
+		}
+
 		// If we are missing both publish-fields, then no need to go further
 		if(!isset($page->publish_until) || !isset($page->publish_from)) return;
 
@@ -139,6 +151,7 @@ class SchedulePages extends WireData implements Module, ConfigurableModule {
 			$page->save();
 			return;
 		}
+
 	}
 
 
@@ -221,7 +234,17 @@ class SchedulePages extends WireData implements Module, ConfigurableModule {
 		$field2->addOption('1', __('Yes'));
 		$field2->notes =  __("If choose yes, all publish and unpublish events will be logged in the messages.txt file in /assets/logs/.");
 		
+		$field3 = $modules->get("InputfieldSelect");
+		$field3->name = "autofillPublishFrom";
+		$field3->label =  __("Always use “Publish From Date” field to store publishing timestamp");
+		$field3->description =  __("Do you want to fill the “Publish From Date” field with the current timestamp in case a page is published manually?");
+		if (isset($data['autofillPublishFrom'])) $field3->value = $data['autofillPublishFrom'];
+		$field3->addOption('0', __('No'));
+		$field3->addOption('1', __('Yes'));
+		$field3->notes =  __("This way the “Publish From Date” field always contains a page’s publishing date – even if there was no scheduling via the “Publish From Date” field.");
+
 		$fields->add($field);
+		$fields->add($field3);
 		$fields->add($field2);
 
 		return $fields;

--- a/SchedulePages.module
+++ b/SchedulePages.module
@@ -105,22 +105,17 @@ class SchedulePages extends WireData implements Module, ConfigurableModule {
 	public function afterSave($event) {
 		$page = $event->arguments[0];
 
+		$currenttime = time();
+
 		// Fill the publish_from field automatically with the current timestamp
 		// in case a page is published manually
-		if ($this->autofillPublishFrom == "1") {
-			// Don’t touch unpublished pages.
-			// Don’t touch pages with the publish_from field already filled.
-			// Don’t touch pages which don’t have a publish_from field.
-			if ($page->is(Page::statusUnpublished) || $page->publish_from || !$page->template->hasField('publish_from')) return;
-			//if page is published and publish_from not populated, add current timestamp
-			$page->publish_from = time();
+		if ($this->autofillPublishFrom == "1" && !$page->is(Page::statusUnpublished) && !$page->publish_from && $page->template->hasField('publish_from')) {
+			$page->publish_from = $currenttime ;
 			$page->save('publish_from');
 		}
 
 		// If we are missing both publish-fields, then no need to go further
 		if(!isset($page->publish_until) || !isset($page->publish_from)) return;
-
-		$currenttime = time();
 
 		// Check if publish_from and _until dates doesn't make any sense and disallow publishing if so
 		if ($page->publish_from > $page->publish_until && $page->publish_from && $page->publish_until) {


### PR DESCRIPTION
If the new option is set to “Yes”, the publish_from field is automatically filled with the current timestamp in case a page is published manually.

This way the “Publish From Date” field always contains a page’s publishing date – even if there was no scheduling via the “Publish From Date” field. This mimics the publish date field behavior of WordPress and is extremely handy if you use the publish_from field in a blog’s front end template.