### PR TITLE
Prevent unintentional re-publishing of pages

### DIFF
--- a/README
+++ b/README
@@ -19,29 +19,34 @@ http://www.ryancramer.com
 
 Usage:
 ======
-1. 	Place the SchedulePages.module file into the 
-	site/modules folder and install the plugin from the admin
-	area.
-	You can choose how often the cron requires to run. (thanks to
-	Apeisa)
-2.	The LazyCron module will be installed (if you haven't already).
-	This module is part of the Processwire core, but it isn't
-	activated by default.
-3.	Add the following date fields to your template: 
-	publish_from
-	publish_until
-	Note: the fields are already created during the 
+1.  Place the SchedulePages.module file into the 
+    site/modules folder and install the plugin from the admin
+    area.
+    You can choose how often the cron requires to run. (thanks to
+    Apeisa)
+2.  The LazyCron module will be installed (if you haven't already).
+    This module is part of the Processwire core, but it isn't
+    activated by default.
+3.  Add the following date fields to your template: 
+    publish_from
+    publish_until
+    Note: the fields are already created during the 
 	installation of the module
-4.	That't all. LazyCron will run take care of (un)publishing
-	your pages that have a the publish dates set.
-	Please note: LazyCron hooks are only executed during 
-	pageviews that are delivered by ProcessWire. They are not 
-	executed when using ProcessWire's API from other scripts.
+4.  That't all. LazyCron will run take care of (un)publishing
+    your pages that have a the publish dates set.
+    Please note: LazyCron hooks are only executed during 
+    pageviews that are delivered by ProcessWire. They are not 
+    executed when using ProcessWire's API from other scripts.
 	
 Version history:
 ================
-1.0.0 	Original version
-1.0.1	Minor bugfixes
-1.1.0	Added debug feature and fixed a publication bug
-1.1.1	Added full language support and renamed $time variable to $currenttime
-1.2.0	Added feature: Always use “Publish From Date” field to store publishing timestamp
+1.0.0  Original version
+1.0.1  Minor bugfixes
+1.1.0  Added debug feature and fixed a publication bug
+1.1.1  Added full language support and renamed $time variable to $currenttime
+1.2.0  Added feature: Always use “Publish From Date” field to store publishing
+       timestamp
+1.2.1  The publish_from field is now automatically cleared when it contains a
+       date from the past and the page is saved unpublished. This prevents the
+       page from being unintentionally published resp. re-published on the next
+       cron run.

--- a/README
+++ b/README
@@ -46,7 +46,6 @@ Version history:
 1.1.1  Added full language support and renamed $time variable to $currenttime
 1.2.0  Added feature: Always use “Publish From Date” field to store publishing
        timestamp
-1.2.1  The publish_from field is now automatically cleared when it contains a
-       date from the past and the page is saved unpublished. This prevents the
-       page from being unintentionally published resp. re-published on the next
-       cron run.
+1.2.1  The publish_from field is now automatically cleared when the page is
+       manually unpublished. This prevents the page from being unintentionally
+       re-published on the next cron run.

--- a/SchedulePages.module
+++ b/SchedulePages.module
@@ -98,9 +98,27 @@ class SchedulePages extends WireData implements Module, ConfigurableModule {
 			$this->addHook('LazyCron::everyHour', $this, 'RunSchedulePages');
 		}
 
+		// add a hook before the $pages->save, to check wheter the publish_from field needs to be cleared
+		$this->pages->addHookBefore('save', $this, 'beforeSave');
+
 		// add a hook after the $pages->save, to check wheter current page should be published or not
 		$this->pages->addHookAfter('save', $this, 'afterSave');
 	}
+
+	public function beforeSave($event) {
+		$page = $event->arguments[0];
+
+		// Clear the publish_from field automatically when the page is manually
+		// unpublished. This prevents the page from being unintentionally
+		// re-published on the next cron run.
+		if ($page->isChanged('status') && $page->is(Page::statusUnpublished) && $page->publish_from) {
+			$this->session->error($this->_("“Publish From Date” field was cleared to prevent the page from being unintentionally re-published on the next Lazy Cron run."));
+			$page->publish_from = null;
+			$page->save('publish_from');
+		}
+
+	}
+
 
 	public function afterSave($event) {
 		$page = $event->arguments[0];
@@ -111,16 +129,6 @@ class SchedulePages extends WireData implements Module, ConfigurableModule {
 		// in case a page is published manually
 		if ($this->autofillPublishFrom == "1" && !$page->is(Page::statusUnpublished) && !$page->publish_from && $page->template->hasField('publish_from')) {
 			$page->publish_from = $currenttime ;
-			$page->save('publish_from');
-		}
-
-		// Clear the publish_from field automatically when it contains a date
-		// from the past and the page is saved unpublished. This prevents the
-		// page from being unintentionally published resp. re-published on the
-		// next cron run.
-		if ($page->is(Page::statusUnpublished) && $page->template->hasField('publish_from') && $page->publish_from < $currenttime) {
-			$this->session->error($this->_("“Publish From Date” field was cleared because it contained a date which lies in the past. This would have caused the page to be (unintentionally) published resp. re-published on the next Lazy Cron run. Obviously this was not your intention since you chose to only save and not publish the page."));
-			$page->publish_from = null;
 			$page->save('publish_from');
 		}
 

--- a/SchedulePages.module
+++ b/SchedulePages.module
@@ -59,7 +59,7 @@ class SchedulePages extends WireData implements Module, ConfigurableModule {
 			'title' => 'Schedule Pages',
 
 			// version: major, minor, revision, i.e. 100 = 1.0.0
-			'version' => 120,
+			'version' => 121,
 
 			// summary is brief description of what this module is
 			'summary' => 'This module allows scheduling (un)publication of pages.',
@@ -111,6 +111,16 @@ class SchedulePages extends WireData implements Module, ConfigurableModule {
 		// in case a page is published manually
 		if ($this->autofillPublishFrom == "1" && !$page->is(Page::statusUnpublished) && !$page->publish_from && $page->template->hasField('publish_from')) {
 			$page->publish_from = $currenttime ;
+			$page->save('publish_from');
+		}
+
+		// Clear the publish_from field automatically when it contains a date
+		// from the past and the page is saved unpublished. This prevents the
+		// page from being unintentionally published resp. re-published on the
+		// next cron run.
+		if ($page->is(Page::statusUnpublished) && $page->template->hasField('publish_from') && $page->publish_from < $currenttime) {
+			$this->session->error($this->_("“Publish From Date” field was cleared because it contained a date which lies in the past. This would have caused the page to be (unintentionally) published resp. re-published on the next Lazy Cron run. Obviously this was not your intention since you chose to only save and not publish the page."));
+			$page->publish_from = null;
 			$page->save('publish_from');
 		}
 


### PR DESCRIPTION
The publish_from field is now automatically cleared when the page is manually unpublished. This prevents the page from being unintentionally re-published on the next cron run.