### PR TITLE
Add composer support

### DIFF
--- a/README
+++ b/README
@@ -37,6 +37,24 @@ Usage:
     Please note: LazyCron hooks are only executed during 
     pageviews that are delivered by ProcessWire. They are not 
     executed when using ProcessWire's API from other scripts.
+
+
+Update via composer:
+====================
+You can load this module by adding this to your composer.json in processwire and run `composer update`
+`
+{
+  "require": {
+    "formmailer/schedulepages": "^1.2.2"
+  },
+  "repositories": [
+    { "type": "github", "url": "https://github.com/formmailer/SchedulePages"  }
+  ]
+}
+`
+Feel free to use your own github url when you have forked this module
+
+
 	
 Version history:
 ================

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,50 @@
+{
+  "name": "formmailer/schedulepages",
+  "description": "This module allows scheduling (un)publication of pages.",
+  "homepage": "http://www.processwire.com/talk/topic/711-release-schedulepages/",
+  "keywords": ["processwire"],
+  "version": "1.2.2",
+  "type": "pw-module",
+  "license": [
+    "GNU/GPL v2"
+  ],
+  "authors": [
+    {
+      "name": "Jasper Metselaar",
+      "email": "jasper@formmailer.net",
+      "role": "Developer",
+      "homepage": "https://github.com/formmailer"
+    },
+    {
+      "name": "Antti Peisa",
+      "email": "antti.peisa@gmail.com",
+      "role": "Developer",
+      "homepage": "https://github.com/apeisa"
+    },
+    {
+      "name": "TeppoKoivula",
+      "email": "teppo@piikkilanka.com",
+      "role": "Developer",
+      "homepage": "https://github.com/teppokoivula"
+    },
+    {
+      "name": "Michael van Laar",
+      "email": "michael@van-laar.de",
+      "role": "Developer",
+      "homepage": "https://github.com/MichaelvanLaar"
+    }
+  ],
+  "support": {
+    "source": "https://github.com/formmailer/SchedulePages/tree/master",
+    "issues": "https://github.com/formmailer/SchedulePages/issues",
+    "forum":  "http://www.processwire.com/talk/topic/711-release-schedulepages/"
+  },
+  "require": {
+    "hari/pw-module": "~1.0"
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "0.2.x-dev"
+    }
+  }
+}


### PR DESCRIPTION
Added composer-support

add this to your processwire composer.json to load the module
```json
{
  "require": {
    "formmailer/schedulepages": "^1.2.2"
  },
  "repositories": [
    { "type": "github", "url": "https://github.com/formmailer/SchedulePages"  }
  ]
}
```

You should add a tag at the merge-point of this Pull-Request (e.g. with this command)
```shell
git tag -a v1.2.2 -m "Minor bugfix. Duplicating pages was not working."
```
to show composer the version.
